### PR TITLE
Fix missing ensemble members

### DIFF
--- a/IBF-Typhoon-model/run_model_V2.R
+++ b/IBF-Typhoon-model/run_model_V2.R
@@ -204,14 +204,11 @@ df_impact_forecast <- as.data.frame(y_predicted) %>%
     GEN_typhoon_id,
     WEA_dist_track,
     WEA_vmax_sust_mhp,
-    # GEN_mun_code,
     e_impact,
     dist50,
     Damaged_houses,
-    # GEN_typhoon_name,
-    # GEN_typhoon_id,
   ) %>%
-  drop_na()
+  drop_na() %>%
   # Add 0 damage tracks to any municipalities with missing members
   # Note that after this step the index is NA for the 0 damage members
   complete(

--- a/IBF-Typhoon-model/run_model_V2.R
+++ b/IBF-Typhoon-model/run_model_V2.R
@@ -212,7 +212,30 @@ df_impact_forecast <- as.data.frame(y_predicted) %>%
     # GEN_typhoon_id,
   ) %>%
   drop_na()
+  # Add 0 damage tracks to any municipalities with missing members
+  # Note that after this step the index is NA for the 0 damage members
+  complete(
+    GEN_typhoon_id, 
+    nesting(
+      region, 
+      GEN_mun_code,
+      GEN_mun_name,
+      GEO_n_households,
+      GEN_typhoon_name
+    ),
+    fill=list(
+      WEA_vmax_sust_mhp=0,
+      e_impact=0,
+      dist50=0,
+      Damaged_houses=0
+    )
+  )
 
+# For debugging if needed: a boxplot showing ensemble distribution of 
+# damanged houses per municipality 
+# boxplot(Damaged_houses~GEN_mun_code, data=df_impact_forecast, range=0, las=2)
+
+Typhoon_stormname <- as.character(unique(wind_grid[['name']])[1])
 
 Typhoon_stormname <- as.character(unique(wind_grid[["name"]])[1])
 

--- a/IBF-Typhoon-model/run_model_V2.R
+++ b/IBF-Typhoon-model/run_model_V2.R
@@ -211,7 +211,7 @@ df_impact_forecast <- as.data.frame(y_predicted) %>%
   drop_na() %>%
   # Add 0 damage tracks to any municipalities with missing members
   # Note that after this step the index is NA for the 0 damage members
-  complete(
+  tidyr::complete(
     GEN_typhoon_id, 
     nesting(
       region, 

--- a/IBF-Typhoon-model/run_model_V2.R
+++ b/IBF-Typhoon-model/run_model_V2.R
@@ -235,8 +235,6 @@ df_impact_forecast <- as.data.frame(y_predicted) %>%
 # damanged houses per municipality 
 # boxplot(Damaged_houses~GEN_mun_code, data=df_impact_forecast, range=0, las=2)
 
-Typhoon_stormname <- as.character(unique(wind_grid[['name']])[1])
-
 Typhoon_stormname <- as.character(unique(wind_grid[["name"]])[1])
 
 ####################################################################################################


### PR DESCRIPTION
Now that the probabilistic forecast is being used, it means that for each typhoon track realization, a different combination of municipalities will be impacted. Thus for a given municipality in the impact table, not all 52 ensemble members will be represented. This will cause e.g. the percentile per municipality to be incorrect, since for the missing ensemble members the predicted number of damaged houses is actually 0. 

This PR tries to address this issue by completing the impact table: that is, making sure that each municipality has all 52 ensemble members, and filling in any missing ones with 0 damaged houses. 

Here is a final boxplot of what the damage per municipality would look like for Surigae:

![9b57a2f7-879f-4044-826d-5a77b996baa9](https://user-images.githubusercontent.com/6585693/129351323-bdd1c8f4-e2b9-43f6-9037-746de4a18b91.png)

The distributions look this way because when damage is predicted, there isn't a lot of spread. So the distributions are probably somewhat bimodal. 

One thing I did notice and wonder about though is that often exact numbers are repeated for the number of damaged houses. For example, in the Aparri municipality, there are three tracks that predict exactly 536 damaged houses, two that predict exactly 465, and the rest zero (and there are many more examples of this for the other municipalities). Do you know why this repitition seems to occur? 