### PR TITLE
Add tables for municipality breakdown 

### DIFF
--- a/IBF-Typhoon-model/lib_r/damage_probability.R
+++ b/IBF-Typhoon-model/lib_r/damage_probability.R
@@ -7,7 +7,6 @@ get_total_impact_forecast <- function(df_impact_forecast, damage_thresholds,
   cnames <- paste0(">=", damage_thresholds / 1000, "k")
   damage_thresholds_named <- setNames(damage_thresholds, cnames)
   # Get the total summarized impact
-  # For some reason if <- is used here the method can't find this var
   df_total_impact_forecast <- df_impact_forecast %>%
     group_by(GEN_typhoon_name, GEN_typhoon_id) %>%
     dplyr::summarise(CDamaged_houses = sum(Damaged_houses)) %>%
@@ -54,6 +53,8 @@ get_total_impact_forecast <- function(df_impact_forecast, damage_thresholds,
     ) %>%
     ungroup() %>%
     add_row(
+      GEN_typhoon_name = "TOTAL",
+      GEN_mun_code = "TOTAL", 
       GEN_mun_name = "TOTAL",
       dplyr::summarise(., across(where(is.numeric), sum))
     ) %>%

--- a/IBF-Typhoon-model/lib_r/damage_probability.R
+++ b/IBF-Typhoon-model/lib_r/damage_probability.R
@@ -57,11 +57,11 @@ get_total_impact_forecast <- function(df_impact_forecast, damage_thresholds, org
   df_mun_impact_forecast = df_impact_forecast %>%
     group_by(GEN_typhoon_name, GEN_mun_code) %>%
     dplyr::summarise(
-      c1=quantile(Damaged_houses, c(probabilities[1])),
-      c2=quantile(Damaged_houses, c(probabilities[2])),
-      c3=quantile(Damaged_houses, c(probabilities[3])),
-      c4=quantile(Damaged_houses, c(probabilities[4])),
-      c5=quantile(Damaged_houses, c(probabilities[5])),
+      c1=quantile(Damaged_houses, c(1-probabilities[1])),
+      c2=quantile(Damaged_houses, c(1-probabilities[2])),
+      c3=quantile(Damaged_houses, c(1-probabilities[3])),
+      c4=quantile(Damaged_houses, c(1-probabilities[4])),
+      c5=quantile(Damaged_houses, c(1-probabilities[5])),
     )
   # Rename the columns
   colnames(df_mun_impact_forecast) = c("Tyhoon_name", "Municipality", cnames)

--- a/IBF-Typhoon-model/lib_r/damage_probability.R
+++ b/IBF-Typhoon-model/lib_r/damage_probability.R
@@ -1,0 +1,75 @@
+# Functions for calculating the damage probabilities
+
+
+get_damage_probability <- function(damaged_houses, threshold, n_ensemble) {
+  return(round(100 * sum(damaged_houses >= threshold) / n_ensemble))
+}
+
+
+get_total_impact_forecast <- function(df_impact_forecast, damage_thresholds, organization){
+  
+  n_ensemble <- length(unique(df_impact_forecast[["GEN_typhoon_id"]])) # usually 52
+  
+  # Get the total summarized impact
+  # For some reason if <- is used here the method can't find this var
+  df_total_impact_forecast = df_impact_forecast %>%
+    group_by(GEN_typhoon_name, GEN_typhoon_id) %>%
+    dplyr::summarise(CDamaged_houses = sum(Damaged_houses)) %>%
+    group_by(GEN_typhoon_name) %>%
+    dplyr::summarise(
+      # TODO: Is there a more elegant way to do this?
+      c1=get_damage_probability(CDamaged_houses, cerf_damage_thresholds[1], n_ensemble), 
+      c2=get_damage_probability(CDamaged_houses, cerf_damage_thresholds[2], n_ensemble), 
+      c3=get_damage_probability(CDamaged_houses, cerf_damage_thresholds[3], n_ensemble), 
+      c4=get_damage_probability(CDamaged_houses, cerf_damage_thresholds[4], n_ensemble), 
+      c5=get_damage_probability(CDamaged_houses, cerf_damage_thresholds[5], n_ensemble), 
+    ) 
+  
+  # Rename the columns
+  # TODO: Are the prefixes really needed?
+  cname_prefix = c("VH", "H", "H", "M", "L")
+  cnames = paste0(cname_prefix, "_", damage_thresholds / 1000, "k")
+  colnames(df_total_impact_forecast) = c("Tyhoon_name", cnames)
+  
+  # Save to CSV
+  write.csv(df_total_impact_forecast,
+            file = paste0(Output_folder, organization, "_TRIGGER_LEVEL_",
+                          forecast_time, "_", Typhoon_stormname, ".csv"),
+            row.names=FALSE)
+  
+  # Print results to terminal
+  # TODO: Doesn't seem to work at the moment
+  df_total_impact_forecast %>%
+    as_hux() %>%
+    set_text_color(1, everywhere, "blue") %>%
+    theme_article() %>%
+    set_caption(
+      paste0(
+        organization,
+        " PROBABILITY FOR THE NUMBER OF COMPLETELY DAMAGED BUILDINGS"
+      )
+    )
+  
+  # Get the impact by municiaplity
+  # TODO: do these change between CERF / DREF?
+  probabilities = c(0.95, 0.80, 0.70, 0.60, 0.50)
+  cnames =  paste0("p", int(probabilities*100))
+  df_mun_impact_forecast = df_impact_forecast %>%
+    group_by(GEN_typhoon_name, GEN_mun_code) %>%
+    dplyr::summarise(
+      c1=quantile(Damaged_houses, c(probabilities[1])),
+      c2=quantile(Damaged_houses, c(probabilities[2])),
+      c3=quantile(Damaged_houses, c(probabilities[3])),
+      c4=quantile(Damaged_houses, c(probabilities[4])),
+      c5=quantile(Damaged_houses, c(probabilities[5])),
+    )
+  # Rename the columns
+  colnames(df_mun_impact_forecast) = c("Tyhoon_name", "Municipality", cnames)
+  # Save to CSV
+  write.csv(df_mun_impact_forecast,
+            file = paste0(Output_folder, organization, "_municipality_breakdown_",
+                          forecast_time, "_", Typhoon_stormname, ".csv"),
+            row.names=FALSE)
+  
+  return(df_total_impact_forecast)
+}

--- a/IBF-Typhoon-model/run_model_V2.R
+++ b/IBF-Typhoon-model/run_model_V2.R
@@ -243,7 +243,6 @@ Typhoon_stormname <- as.character(unique(wind_grid[["name"]])[1])
 
 # Items needed for probability calculation
 
-
 get_damage_probability <- function(damaged_houses, threshold, n_ensemble) {
   return(round(100 * sum(damaged_houses >= threshold) / n_ensemble))
 }
@@ -267,15 +266,18 @@ get_total_impact_forecast <- function(df_impact_forecast, damage_thresholds, org
      ) 
 
   # Rename the columns
+  # TODO: Are the prefixes really needed?
   cname_prefix = c("VH", "H", "H", "M", "L")
   cnames = paste0(cname_prefix, "_", damage_thresholds / 1000, "k")
   colnames(df_total_impact_forecast) = c("Tyhoon_name", cnames)
 
   write.csv(df_total_impact_forecast,
             file = paste0(Output_folder, organization, "_TRIGGER_LEVEL_",
-                          forecast_time, "_", Typhoon_stormname, ".csv"))
+                          forecast_time, "_", Typhoon_stormname, ".csv"),
+            row.names=FALSE)
 
   # Print results to terminal
+  # TODO: Doesn't seem to work at the moment
   df_total_impact_forecast %>%
     as_hux() %>%
     set_text_color(1, everywhere, "blue") %>%

--- a/IBF-Typhoon-model/run_model_V2.R
+++ b/IBF-Typhoon-model/run_model_V2.R
@@ -47,19 +47,24 @@ source("lib_r/damage_probability.R")
 
 # php_admin3 <- st_read(dsn=paste0(main_directory,'data-raw'),layer='phl_admin3_simpl2')
 php_admin3 <- geojsonsf::geojson_sf(
-  paste0(main_directory, "data-raw/phl_admin3_simpl2.geojson"))
+  paste0(main_directory, "data-raw/phl_admin3_simpl2.geojson")
+)
 
 # php_admin1 <- st_read(dsn=paste0(main_directory,'data-raw'),layer='phl_admin1_gadm_pcode')
 php_admin1 <- geojsonsf::geojson_sf(
-  paste0(main_directory, "data-raw/phl_admin1_gadm_pcode.geojson"))
+  paste0(main_directory, "data-raw/phl_admin1_gadm_pcode.geojson")
+)
 
 wshade <- php_admin3
 material_variable2 <- read.csv(
-  paste0(main_directory, "data/material_variable2.csv"))
+  paste0(main_directory, "data/material_variable2.csv")
+)
 data_matrix_new_variables <- read.csv(
-  paste0(main_directory, "data/data_matrix_new_variables.csv"))
+  paste0(main_directory, "data/data_matrix_new_variables.csv")
+)
 geo_variable <- read.csv(
-  paste0(main_directory, "data/geo_variable.csv"))
+  paste0(main_directory, "data/geo_variable.csv")
+)
 
 wshade <- php_admin3
 # load the rr model
@@ -68,28 +73,34 @@ wshade <- php_admin3
 # mode_classification1 <- readRDS(paste0(main_directory,"./models/xgboost_classify.rds"))
 
 xgmodel <- readRDS(
-  paste0(main_directory, "/models/operational/xgboost_regression_v2.RDS"), 
+  paste0(main_directory, "/models/operational/xgboost_regression_v2.RDS"),
   refhook = NULL
-  )
+)
 
 # load forecast data
 typhoon_info_for_model <- read.csv(
-  paste0(main_directory, "/forecast/Input/typhoon_info_for_model.csv"))
+  paste0(main_directory, "/forecast/Input/typhoon_info_for_model.csv")
+)
 # typhoon_events <- read.csv(paste0(main_directory,'/forecast/Input/typhoon_info_for_model.csv'))
 
 
 rain_directory <- as.character(
-  typhoon_info_for_model[typhoon_info_for_model[["source"]] == "Rainfall", ][["filename"]])
+  typhoon_info_for_model[typhoon_info_for_model[["source"]] == "Rainfall", ][["filename"]]
+)
 windfield_data <- as.character(
-  typhoon_info_for_model[typhoon_info_for_model[["source"]] == "windfield", ][["filename"]])
+  typhoon_info_for_model[typhoon_info_for_model[["source"]] == "windfield", ][["filename"]]
+)
 ECMWF_ <- as.character(
-  typhoon_info_for_model[typhoon_info_for_model[["source"]] == "ecmwf", ][["filename"]])
+  typhoon_info_for_model[typhoon_info_for_model[["source"]] == "ecmwf", ][["filename"]]
+)
 TRACK_DATA <- read.csv(ECMWF_) # %>%dplyr::mutate(STORMNAME=Typhoon_stormname, YYYYMMDDHH=format(strptime(YYYYMMDDHH, format = "%Y-%m-%d %H:%M:%S"), '%Y%m%d%H%00'))
 
 Output_folder <- as.character(
-  typhoon_info_for_model[typhoon_info_for_model[["source"]] == "Output_folder", ][["filename"]])
+  typhoon_info_for_model[typhoon_info_for_model[["source"]] == "Output_folder", ][["filename"]]
+)
 forecast_time <- as.character(
-  typhoon_info_for_model[typhoon_info_for_model[["source"]] == "ecmwf", ][["time"]])
+  typhoon_info_for_model[typhoon_info_for_model[["source"]] == "ecmwf", ][["time"]]
+)
 
 #------------------------- define functions ---------------------------------
 
@@ -107,10 +118,10 @@ ntile_na <- function(x, n) {
 
 
 
-wind_grid <- read.csv(windfield_data) %>% 
+wind_grid <- read.csv(windfield_data) %>%
   dplyr::mutate(
-    dis_track_min = ifelse(dis_track_min < 1, 1, dis_track_min), 
-    Mun_Code = adm3_pcode, 
+    dis_track_min = ifelse(dis_track_min < 1, 1, dis_track_min),
+    Mun_Code = adm3_pcode,
     pcode = as.factor(substr(adm3_pcode, 1, 10))
   )
 
@@ -132,23 +143,24 @@ typhoon_hazard <- wind_grid %>%
     vmax_sust = v_max
   ) %>%
   # 1.21 is conversion factor for 10 min average to 1min average
-  dplyr::select(Mun_Code, vmax_gust, 
-                vmax_gust_mph, vmax_sust_mph, 
-                vmax_sust, dist_track, 
-                rainfall_24h, gust_dur, 
-                sust_dur, ranfall_sum, 
-                storm_id, typhoon_name
-                )
+  dplyr::select(
+    Mun_Code, vmax_gust,
+    vmax_gust_mph, vmax_sust_mph,
+    vmax_sust, dist_track,
+    rainfall_24h, gust_dur,
+    sust_dur, ranfall_sum,
+    storm_id, typhoon_name
+  )
 
 
 # BUILD DATA MATRIC FOR NEW TYPHOON
 data_new_typhoon1 <- geo_variable %>%
-  left_join(material_variable2 %>% 
-              dplyr::select(
-                -Region, 
-                -Province, 
-                -Municipality_City
-              ), by = "Mun_Code") %>%
+  left_join(material_variable2 %>%
+    dplyr::select(
+      -Region,
+      -Province,
+      -Municipality_City
+    ), by = "Mun_Code") %>%
   left_join(data_matrix_new_variables, by = "Mun_Code") %>%
   left_join(typhoon_hazard, by = "Mun_Code") %>%
   na.omit()
@@ -212,24 +224,24 @@ df_impact_forecast <- as.data.frame(y_predicted) %>%
   # Add 0 damage tracks to any municipalities with missing members
   # Note that after this step the index is NA for the 0 damage members
   complete(
-    GEN_typhoon_id, 
+    GEN_typhoon_id,
     nesting(
-      region, 
+      region,
       GEN_mun_code,
       GEN_mun_name,
       GEO_n_households,
       GEN_typhoon_name
     ),
-    fill=list(
-      WEA_vmax_sust_mhp=0,
-      e_impact=0,
-      dist50=0,
-      Damaged_houses=0
+    fill = list(
+      WEA_vmax_sust_mhp = 0,
+      e_impact = 0,
+      dist50 = 0,
+      Damaged_houses = 0
     )
   )
 
-# For debugging if needed: a boxplot showing ensemble distribution of 
-# damanged houses per municipality 
+# For debugging if needed: a boxplot showing ensemble distribution of
+# damanged houses per municipality
 # boxplot(Damaged_houses~GEN_mun_code, data=df_impact_forecast, range=0, las=2)
 
 Typhoon_stormname <- as.character(unique(wind_grid[["name"]])[1])
@@ -238,21 +250,24 @@ Typhoon_stormname <- as.character(unique(wind_grid[["name"]])[1])
 # ------------------------ calculate  probability only for region 5 and 8  -----------------------------------
 
 # Only select regions 5 and 8
-cerf_regions = c("PH05", "PH08")
-cerf_damage_thresholds = c(80000, 50000, 30000, 10000, 5000)
+cerf_regions <- c("PH05", "PH08")
+cerf_damage_thresholds <- c(80000, 50000, 30000, 10000, 5000)
+probabilities <- c(0.95, 0.80, 0.70, 0.60, 0.50)
 
 df_impact_forecast_CERF <- get_total_impact_forecast(
   df_impact_forecast %>% filter(region %in% cerf_regions),
-  cerf_damage_thresholds, "CERF")
+  cerf_damage_thresholds, probabilities, "CERF"
+)
 
 
 ####################################################################################################
 # ------------------------ calculate and plot probability National -----------------------------------
 
-dref_damage_thresholds = c(100000, 80000, 70000, 50000, 30000)
+dref_damage_thresholds <- c(100000, 80000, 70000, 50000, 30000)
 
 df_impact_forecast_DREF <- get_total_impact_forecast(
-  df_impact_forecast, dref_damage_thresholds, "DREF")
+  df_impact_forecast, dref_damage_thresholds, probabilities, "DREF"
+)
 
 
 # ------------------------ calculate average impact vs probability   -----------------------------------
@@ -260,30 +275,34 @@ df_impact_forecast_DREF <- get_total_impact_forecast(
 n_ensemble <- length(unique(df_impact_forecast[["GEN_typhoon_id"]])) # usually 52
 
 df_impact_dist50 <- aggregate(
-    df_impact_forecast[["dist50"]], 
-    by = list(GEN_mun_code = df_impact_forecast[["GEN_mun_code"]]), 
-    FUN = sum
-  ) %>%
+  df_impact_forecast[["dist50"]],
+  by = list(GEN_mun_code = df_impact_forecast[["GEN_mun_code"]]),
+  FUN = sum
+) %>%
   dplyr::mutate(probability_dist50 = 100 * x / n_ensemble) %>%
   dplyr::select(GEN_mun_code, probability_dist50) %>%
   left_join(
     aggregate(
-      df_impact_forecast[["e_impact"]], 
-      by = list(GEN_mun_code = df_impact_forecast[["GEN_mun_code"]]), 
+      df_impact_forecast[["e_impact"]],
+      by = list(GEN_mun_code = df_impact_forecast[["GEN_mun_code"]]),
       FUN = sum
     ) %>%
-    dplyr::mutate(impact = x / n_ensemble) %>%
-      dplyr::select(GEN_mun_code, impact), by = "GEN_mun_code") %>%
+      dplyr::mutate(impact = x / n_ensemble) %>%
+      dplyr::select(GEN_mun_code, impact),
+    by = "GEN_mun_code"
+  ) %>%
   left_join(
     aggregate(
-      df_impact_forecast[["WEA_dist_track"]], 
-      by = list(GEN_mun_code = df_impact_forecast[["GEN_mun_code"]]), 
+      df_impact_forecast[["WEA_dist_track"]],
+      by = list(GEN_mun_code = df_impact_forecast[["GEN_mun_code"]]),
       FUN = sum
     ) %>%
-    dplyr::mutate(WEA_dist_track = x / n_ensemble) %>% 
-      dplyr::select(GEN_mun_code, WEA_dist_track), by = "GEN_mun_code")
+      dplyr::mutate(WEA_dist_track = x / n_ensemble) %>%
+      dplyr::select(GEN_mun_code, WEA_dist_track),
+    by = "GEN_mun_code"
+  )
 
-df_impact <- df_impact_forecast %>% 
+df_impact <- df_impact_forecast %>%
   left_join(df_impact_dist50, by = "GEN_mun_code")
 
 
@@ -310,33 +329,37 @@ df_impact <- df_impact_forecast %>%
 
 # ------------------------ calculate probability   -----------------------------------
 
-event_impact <- php_admin3 %>% 
+event_impact <- php_admin3 %>%
   left_join(
-    df_impact_dist50 %>% 
-      dplyr::mutate(adm3_pcode = GEN_mun_code), 
-    by = "adm3_pcode")
+    df_impact_dist50 %>%
+      dplyr::mutate(adm3_pcode = GEN_mun_code),
+    by = "adm3_pcode"
+  )
 
-track <- track_interpolation(TRACK_DATA) %>% 
+track <- track_interpolation(TRACK_DATA) %>%
   dplyr::mutate(Data_Provider = "ECMWF_HRS")
 
-maps <- Make_maps_avg(php_admin1, 
-                      event_impact, 
-                      track, 
-                      TYF = "ECMWF", 
-                      Typhoon_stormname)
+maps <- Make_maps_avg(php_admin1,
+  event_impact,
+  track,
+  TYF = "ECMWF",
+  Typhoon_stormname
+)
 
 ####################################################################################################
 # ------------------------ save impact data to file   -
 
-tmap_save(maps, 
-          filename = paste0(Output_folder, "Average_Impact_", "_", forecast_time, "_", Typhoon_stormname, ".png"), 
-          width = 20, height = 24, dpi = 600, units = "cm")
+tmap_save(maps,
+  filename = paste0(Output_folder, "Average_Impact_", "_", forecast_time, "_", Typhoon_stormname, ".png"),
+  width = 20, height = 24, dpi = 600, units = "cm"
+)
 
 ####################################################################################################
 # ------------------------ save impact data to file   -----------------------------------
 
-write.csv(event_impact, 
-          file = paste0(Output_folder, "Average_Impact_", "_", forecast_time, "_", Typhoon_stormname, ".csv"))
+write.csv(event_impact,
+  file = paste0(Output_folder, "Average_Impact_", "_", forecast_time, "_", Typhoon_stormname, ".csv")
+)
 
 file_names <- c(
   paste0(Output_folder, "Average_Impact_", "_", forecast_time, "_", Typhoon_stormname, ".png"),
@@ -345,9 +368,10 @@ file_names <- c(
   paste0(Output_folder, "Average_Impact_", "_", forecast_time, "_", Typhoon_stormname, ".csv")
 )
 
-write.table(file_names, 
-            file = paste0(Output_folder, "model_output_file_names.csv"), 
-            sep = ";", append = FALSE, col.names = FALSE)
+write.table(file_names,
+  file = paste0(Output_folder, "model_output_file_names.csv"),
+  sep = ";", append = FALSE, col.names = FALSE
+)
 
 
 

--- a/IBF-Typhoon-model/run_model_V2.R
+++ b/IBF-Typhoon-model/run_model_V2.R
@@ -350,22 +350,22 @@ maps <- Make_maps_avg(php_admin1,
 # ------------------------ save impact data to file   -
 
 tmap_save(maps,
-  filename = paste0(Output_folder, "Average_Impact_", "_", forecast_time, "_", Typhoon_stormname, ".png"),
+  filename = paste0(Output_folder, "Average_Impact", "_", forecast_time, "_", Typhoon_stormname, ".png"),
   width = 20, height = 24, dpi = 600, units = "cm"
 )
 
 ####################################################################################################
 # ------------------------ save impact data to file   -----------------------------------
 
-write.csv(event_impact,
-  file = paste0(Output_folder, "Average_Impact_", "_", forecast_time, "_", Typhoon_stormname, ".csv")
+write.csv(data.frame(event_impact) %>% dplyr::select(-c(geometry)),
+  file = paste0(Output_folder, "Average_Impact", "_", forecast_time, "_", Typhoon_stormname, ".csv")
 )
 
 file_names <- c(
-  paste0(Output_folder, "Average_Impact_", "_", forecast_time, "_", Typhoon_stormname, ".png"),
+  paste0(Output_folder, "Average_Impact", "_", forecast_time, "_", Typhoon_stormname, ".png"),
   paste0(Output_folder, "DREF_TRIGGER_LEVEL_", forecast_time, "_", Typhoon_stormname, ".csv"),
   paste0(Output_folder, "CERF_TRIGGER_LEVEL_", forecast_time, "_", Typhoon_stormname, ".csv"),
-  paste0(Output_folder, "Average_Impact_", "_", forecast_time, "_", Typhoon_stormname, ".csv")
+  paste0(Output_folder, "Average_Impact", "_", forecast_time, "_", Typhoon_stormname, ".csv")
 )
 
 write.table(file_names,

--- a/IBF-Typhoon-model/run_model_V2.R
+++ b/IBF-Typhoon-model/run_model_V2.R
@@ -237,7 +237,8 @@ Typhoon_stormname <- as.character(unique(wind_grid[["name"]])[1])
 ####################################################################################################
 # ------------------------ calculate  probability only for region 5 and 8  -----------------------------------
 
-cerf_regions = c("PH02", "PH08")
+# Only select regions 5 and 8
+cerf_regions = c("PH05", "PH08")
 cerf_damage_thresholds = c(80000, 50000, 30000, 10000, 5000)
 
 df_impact_forecast_CERF <- get_total_impact_forecast(

--- a/IBF-Typhoon-model/run_model_V2.R
+++ b/IBF-Typhoon-model/run_model_V2.R
@@ -22,7 +22,7 @@ rainfall_error <- args[1]
 sf_use_s2(FALSE)
 # path='C:/Users/ATeklesadik/OneDrive - Rode Kruis/Documents/documents/Typhoon-Impact-based-forecasting-model/IBF-Typhoon-model/'
 path <- "/home/fbf/"
-path='./'
+# path='./'
 main_directory <- path
 
 ###########################################################################

--- a/IBF-Typhoon-model/run_model_V2.R
+++ b/IBF-Typhoon-model/run_model_V2.R
@@ -22,7 +22,7 @@ rainfall_error <- args[1]
 sf_use_s2(FALSE)
 # path='C:/Users/ATeklesadik/OneDrive - Rode Kruis/Documents/documents/Typhoon-Impact-based-forecasting-model/IBF-Typhoon-model/'
 path <- "/home/fbf/"
-# path='./'
+path='./'
 main_directory <- path
 
 ###########################################################################
@@ -211,7 +211,7 @@ df_impact_forecast <- as.data.frame(y_predicted) %>%
     # GEN_typhoon_name,
     # GEN_typhoon_id,
   ) %>%
-  drop_na()
+  drop_na() %>%
   # Add 0 damage tracks to any municipalities with missing members
   # Note that after this step the index is NA for the 0 damage members
   complete(
@@ -237,92 +237,88 @@ df_impact_forecast <- as.data.frame(y_predicted) %>%
 
 Typhoon_stormname <- as.character(unique(wind_grid[["name"]])[1])
 
+
+
+###################################################################################################
+
+# Items needed for probability calculation
+
+
+get_damage_probability <- function(damaged_houses, threshold, n_ensemble) {
+  return(round(100 * sum(damaged_houses >= threshold) / n_ensemble))
+}
+
+get_total_impact_forecast <- function(df_impact_forecast, damage_thresholds, organization){
+  
+  n_ensemble <- length(unique(df_impact_forecast[["GEN_typhoon_id"]])) # usually 52
+
+  # For some reason if <- is used here the method can't find this var
+  df_total_impact_forecast = df_impact_forecast %>%
+    group_by(GEN_typhoon_name, GEN_typhoon_id) %>%
+    dplyr::summarise(CDamaged_houses = sum(Damaged_houses)) %>%
+    group_by(GEN_typhoon_name) %>%
+     dplyr::summarise(
+       # TODO: Is there a more elegant way to do this?
+       c1=get_damage_probability(CDamaged_houses, cerf_damage_thresholds[1], n_ensemble), 
+       c2=get_damage_probability(CDamaged_houses, cerf_damage_thresholds[2], n_ensemble), 
+       c3=get_damage_probability(CDamaged_houses, cerf_damage_thresholds[3], n_ensemble), 
+       c4=get_damage_probability(CDamaged_houses, cerf_damage_thresholds[4], n_ensemble), 
+       c5=get_damage_probability(CDamaged_houses, cerf_damage_thresholds[5], n_ensemble), 
+     ) 
+
+  # Rename the columns
+  cname_prefix = c("VH", "H", "H", "M", "L")
+  cnames = paste0(cname_prefix, "_", damage_thresholds / 1000, "k")
+  colnames(df_total_impact_forecast) = c("Tyhoon_name", cnames)
+
+  write.csv(df_total_impact_forecast,
+            file = paste0(Output_folder, organization, "_TRIGGER_LEVEL_",
+                          forecast_time, "_", Typhoon_stormname, ".csv"))
+
+  # Print results to terminal
+  df_total_impact_forecast %>%
+    as_hux() %>%
+    set_text_color(1, everywhere, "blue") %>%
+    theme_article() %>%
+    set_caption(
+      paste0(
+        organization,
+        " PROBABILITY FOR THE NUMBER OF COMPLETELY DAMAGED BUILDINGS"
+      )
+    )
+
+  return(df_total_impact_forecast)
+}
 ####################################################################################################
 # ------------------------ calculate  probability only for region 5 and 8  -----------------------------------
 
-df_impact_forecast_CERF <- df_impact_forecast %>%
-  filter(region %in% c("PH02", "PH08")) %>%
-  group_by(GEN_typhoon_name, GEN_typhoon_id) %>%
-  dplyr::summarise(CDamaged_houses = sum(Damaged_houses)) %>%
-  dplyr::mutate(DM_CLASS = ifelse(CDamaged_houses >= 80000, 5,
-    ifelse(CDamaged_houses >= 50000, 4,
-      ifelse(CDamaged_houses >= 30000, 3,
-        ifelse(CDamaged_houses >= 10000, 2,
-          ifelse(CDamaged_houses >= 5000, 1, 0)
-        )
-      )
-    )
-  )) %>%
-  ungroup() %>%
-  group_by(GEN_typhoon_name) %>%
-  dplyr::summarise(
-    VH_80K = round(100 * sum(DM_CLASS >= 5) / 52),
-    H_50K = round(100 * sum(DM_CLASS >= 4) / 52),
-    H_30K = round(100 * sum(DM_CLASS >= 3) / 52),
-    M_10K = round(100 * sum(DM_CLASS >= 2) / 52),
-    L_5K = round(100 * sum(DM_CLASS >= 1) / 52)
-  ) %>%
-  ungroup() %>%
-  dplyr::rename(Typhoon_name = GEN_typhoon_name)
+cerf_regions = c("PH02", "PH08")
+cerf_damage_thresholds = c(80000, 50000, 30000, 10000, 5000)
 
-write.csv(df_impact_forecast_CERF, 
-          file = paste0(Output_folder, "CERF_TRIGGER_LEVEL_", forecast_time, "_", Typhoon_stormname, ".csv"))
+df_impact_forecast_CERF <- get_total_impact_forecast(
+  df_impact_forecast, #%>% filter(region %in% cerf_regions),
+  cerf_damage_thresholds, "CERF")
 
-df_impact_forecast_CERF %>%
-  as_hux() %>%
-  set_text_color(1, everywhere, "blue") %>%
-  theme_article() %>%
-  set_caption("PROBABILITY FOR THE NUMBER OF COMPLETELY DAMAGED BUILDINGS") # (Region 5 and 8)
 
 ####################################################################################################
 # ------------------------ calculate and plot probability National -----------------------------------
 
-df_impact_forecast_dref <- df_impact_forecast %>%
-  group_by(GEN_typhoon_name, GEN_typhoon_id) %>%
-  dplyr::summarise(CDamaged_houses = sum(Damaged_houses)) %>%
-  dplyr::mutate(DM_CLASS = ifelse(CDamaged_houses >= 100000, 5,
-    ifelse(CDamaged_houses >= 80000, 4,
-      ifelse(CDamaged_houses >= 70000, 3,
-        ifelse(CDamaged_houses >= 50000, 2,
-          ifelse(CDamaged_houses >= 30000, 1, 0)
-        )
-      )
-    )
-  )) %>%
-  ungroup() %>%
-  group_by(GEN_typhoon_name) %>%
-  dplyr::summarise(
-    VH_100K = round(100 * sum(DM_CLASS >= 5) / 52),
-    H_80K = round(100 * sum(DM_CLASS >= 4) / 52),
-    H_70K = round(100 * sum(DM_CLASS >= 3) / 52),
-    M_50K = round(100 * sum(DM_CLASS >= 2) / 52),
-    L_30K = round(100 * sum(DM_CLASS >= 1) / 52)
-  ) %>%
-  ungroup() %>%
-  dplyr::rename(Typhoon_name = GEN_typhoon_name)
+dref_damage_thresholds = c(100000, 80000, 70000, 50000, 30000)
 
-
-df_impact_forecast_dref %>%
-  as_hux() %>%
-  set_text_color(1, everywhere, "blue") %>%
-  theme_article() %>%
-  set_caption("PROBABILITY FOR THE NUMBER OF COMPLETELY DAMAGED BUILDINGS")
-
-
-
-write.csv(df_impact_forecast_dref, file = paste0(Output_folder, "DREF_TRIGGER_LEVEL_", forecast_time, "_", Typhoon_stormname, ".csv"))
+df_impact_forecast_DREF <- get_total_impact_forecast(
+  df_impact_forecast, dref_damage_thresholds, "DREF")
 
 
 # ------------------------ calculate average impact vs probability   -----------------------------------
 
-number_ensambles <- length(unique(df_impact_forecast[["GEN_typhoon_id"]]))
+n_ensemble <- length(unique(df_impact_forecast[["GEN_typhoon_id"]])) # usually 52
 
 df_impact_dist50 <- aggregate(
     df_impact_forecast[["dist50"]], 
     by = list(GEN_mun_code = df_impact_forecast[["GEN_mun_code"]]), 
     FUN = sum
   ) %>%
-  dplyr::mutate(probability_dist50 = 100 * x / number_ensambles) %>%
+  dplyr::mutate(probability_dist50 = 100 * x / n_ensemble) %>%
   dplyr::select(GEN_mun_code, probability_dist50) %>%
   left_join(
     aggregate(
@@ -330,7 +326,7 @@ df_impact_dist50 <- aggregate(
       by = list(GEN_mun_code = df_impact_forecast[["GEN_mun_code"]]), 
       FUN = sum
     ) %>%
-    dplyr::mutate(impact = x / number_ensambles) %>%
+    dplyr::mutate(impact = x / n_ensemble) %>%
       dplyr::select(GEN_mun_code, impact), by = "GEN_mun_code") %>%
   left_join(
     aggregate(
@@ -338,7 +334,7 @@ df_impact_dist50 <- aggregate(
       by = list(GEN_mun_code = df_impact_forecast[["GEN_mun_code"]]), 
       FUN = sum
     ) %>%
-    dplyr::mutate(WEA_dist_track = x / number_ensambles) %>% 
+    dplyr::mutate(WEA_dist_track = x / n_ensemble) %>% 
       dplyr::select(GEN_mun_code, WEA_dist_track), by = "GEN_mun_code")
 
 df_impact <- df_impact_forecast %>% 


### PR DESCRIPTION
- refactor the table creation to separate function, which can be applied to both CERF and DREF thresholds
- create table broken down by municipality. For this table, need to use the probabilities instead of damage thresholds, since individual municipalities will have fewer houses damaged. @aklilu does DREF use the same probability thresholds as CERF? 
- @aklilu the terminal printing function doesn't seem to work for me anymore -- does it work for you? 
- @aklilu do you know a better way to do the "summarise" function [here](https://github.com/rodekruis/Typhoon-Impact-based-forecasting-model/pull/46/files#diff-6671326a4172f004aa9a7d981f60c94f89d5d61e1f20f07d5d2803f428c78387R13-R18) that would avoid repetition? 