### PR TITLE
Pin numba and downgrade numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ h5py>=2.10
 haversine>=2.3
 matplotlib>=3.2
 netcdf4>=1.5
-numba>=0.51
+numba==0.54
 openpyxl>=3.0
 pandas-datareader>=0.9
 pathos>=0.2
@@ -44,7 +44,7 @@ click==8.0.1
 feedparser==6.0.8
 geopandas==0.9.0
 lxml==4.6.3
-numpy==1.21.1
+numpy==1.20
 pandas==1.3.1
 pybufrkit==0.2.19
 Rtree==0.9.4


### PR DESCRIPTION
Numba now has a req for numpy <= 1.20, and it doesn't work otherwise. I've downgraded numpy and pinned numba. (We should probably pin all the other reqs eventually too)