### PR TITLE
Switch to env vars and docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,24 +143,11 @@ cython_debug/
 # Python notebooks
 *.ipynb
 
-# Cutsom by Aki
-settings.py
-PostLandfallAnalysis
-analysis
-typhoon_infographic
-trigger_level_analysis
-home
-otherfiles
-temp
-IBF-Typhoon-model/forecast/
-IBF-Typhoon-model/typhoon_infographic/
-IBF-Typhoon-model/old_scripts/
-IBF-Typhoon-model/models/other_models/*
-IBF-Typhoon-model/lib/secrets.py
-IBF-Typhoon-model/lib/settings.py
-IBF-Typhoon-model/lib/variables.py
-IBF-Typhoon-model/lib/climada_python-main
-IBF-Typhoon-model/mainpipeline_win.py
-IBF-Typhoon-model/model_trigger.py
-IBF-Typhoon-model/credentials
-.Rproj.user
+# R files
+**/.Rproj.user
+**/*.Rproj
+
+# Custom
+secrets
+**/forecast
+

--- a/IBF-Typhoon-model/lib_r/Make_maps.R
+++ b/IBF-Typhoon-model/lib_r/Make_maps.R
@@ -116,7 +116,7 @@ Make_maps_avg<-function(php_admin1,php_admin3_,my_track,TYF,Typhoon_stormname,ma
   ph_map2 = tm_shape(php_admin1)+ tm_polygons(border.col = "white",lwd = 0.01,lyt='dotted',alpha =0.2) +
     #tm_shape(typhoon_region) +# tm_borders(lwd = 2,col='red') +
     tm_credits( subtitle,position = c("left", "top"),size = 0.7) +
-    tm_logo(paste0(path,'logos/combined_logo.png'),#https://www.510.global/wp-content/uploads/2017/07/510-LOGO-WEBSITE-01.png', 
+    tm_logo('logos/combined_logo.png',#https://www.510.global/wp-content/uploads/2017/07/510-LOGO-WEBSITE-01.png', 
             height=3, position = c("right", "top"))+
     tm_layout(legend.show = FALSE)
   

--- a/IBF-Typhoon-model/lib_r/Read_rainfall_v2.R
+++ b/IBF-Typhoon-model/lib_r/Read_rainfall_v2.R
@@ -25,15 +25,15 @@ Read_rainfall_v2<-function(wshade){
     
     # Get the data
           for (i in 2:length(head(model.parameters$pred,n=72))){
-            grib.info <- GribGrab(urls.out[2], model.parameters$pred[i], levels, variables,local.dir = paste0(path, "/forecast/rainfall"))
+            grib.info <- GribGrab(urls.out[2], model.parameters$pred[i], levels, variables,local.dir = "forecast/rainfall")
           }
                     
-          file_list <- list.files(path=paste0(path, "/forecast/rainfall"))
+          file_list <- list.files("forecast/rainfall")
           xx <- raster::stack()   # Read each grib file to a raster and stack it to xx  
           
           
           for (files in file_list)  {
-            fn <- file.path(paste0(path, "/forecast/rainfall"), files)
+            fn <- file.path("forecast/rainfall", files)
             r2 <- raster(fn)
             x1 <- crop(r2, e)
             xx <- raster::stack(xx, x1)

--- a/IBF-Typhoon-model/src/typhoonmodel/pipeline.py
+++ b/IBF-Typhoon-model/src/typhoonmodel/pipeline.py
@@ -321,12 +321,12 @@ def main(path,remote_directory,typhoonname):
             Sendemail.sendemail(
                 smtp_server=os.environ["SMTP_SERVER"],
                 smtp_port=int(os.environ["SMTP_PORT"]),
-                email_username=os.environ["eMAIL_LOGIN"],
-                email_password=os.environ["eMAIL_PASSWORD"],
+                email_username=os.environ["EMAIL_LOGIN"],
+                email_password=os.environ["EMAIL_PASSWORD"],
                 email_subject='Updated impact map for a new Typhoon in PAR',
                 from_address=os.environ["EMAIL_FROM"],
-                to_address_list=os.environ["EMAIL_LIST"].split(','),
-                cc_address_list=os.environ["CC_LIST"].split(','),
+                to_address_list=os.environ["EMAIL_TO_LIST"].split(','),
+                cc_address_list=os.environ["EMAIL_CC_LIST"].split(','),
                 message_html=message_html,
                 filename_list=image_filenames + data_filenames
             )
@@ -335,7 +335,6 @@ def main(path,remote_directory,typhoonname):
 
     print('---------------------AUTOMATION SCRIPT FINISHED---------------------------------')
     print(str(datetime.now()))
-    
 
 
 #%%#Download rainfall (old pipeline)

--- a/IBF-Typhoon-model/src/typhoonmodel/pipeline.py
+++ b/IBF-Typhoon-model/src/typhoonmodel/pipeline.py
@@ -8,7 +8,6 @@ Created on Sat Oct 31 16:01:00 2020
 """
 import time
 import ftplib
-import sys
 import os
 from datetime import datetime, timedelta
 from sys import platform
@@ -23,10 +22,7 @@ import numpy as np
 from geopandas.tools import sjoin
 import geopandas as gpd
 import click
-decoder = Decoder()
 
-#%%
-from typhoonmodel import settings
 from climada.hazard import Centroids, TropCyclone,TCTracks
 from climada.hazard.tc_tracks_forecast import TCForecast
 from typhoonmodel.utility_fun import track_data_clean,Check_for_active_typhoon,Sendemail,ucl_data, plot_intensity
@@ -36,6 +32,7 @@ if platform == "linux" or platform == "linux2": #check if running on linux or wi
 elif platform == "win32":
     from typhoonmodel.utility_fun import Rainfall_data_window as Rainfall_data
 
+decoder = Decoder()
 
 # Set up logger
 logging.root.handlers = []
@@ -53,12 +50,10 @@ ECMWF_MAX_TRIES = 3
 ECMWF_SLEEP = 30  # s
 
 
-
 @click.command()
 @click.option('--path', default='./', help='main directory')
 @click.option('--remote_directory', default=None, help='remote directory for ECMWF forecast data') #'20210421120000'
 @click.option('--typhoonname', default='SURIGAE',help='name for active typhoon')
-       
 def main(path,remote_directory,typhoonname):
     start_time = datetime.now()
     print('---------------------AUTOMATION SCRIPT STARTED---------------------------------')
@@ -111,12 +106,10 @@ def main(path,remote_directory,typhoonname):
     ###### download UCL data
       
     try:
-        ucl_data.create_ucl_metadata(path,settings.uCL_USERNAME,settings.uCL_PASSWORD)
-        ucl_data.process_ucl_data(path,Input_folder,settings.uCL_USERNAME,settings.uCL_PASSWORD)
-        logging.info(f'UCL download failed')
-
+        ucl_data.create_ucl_metadata(path, os.environ['UCL_USERNAME'], os.environ['UCL_PASSWORD'])
+        ucl_data.process_ucl_data(path, Input_folder, os.environ['UCL_USERNAME'], os.environ['UCL_PASSWORD'])
     except:
-        pass
+        logging.info(f'UCL download failed')
     #%%
     ##Create grid points to calculate Winfield
     cent = Centroids()
@@ -326,14 +319,14 @@ def main(path,remote_directory,typhoonname):
             </html>
             """
             Sendemail.sendemail(
-                smtp_server=settings.sMTP_SERVER,
-                smtp_port=settings.sMTP_PORT,
-                email_username=settings.eMAIL_LOGIN,
-                email_password=settings.eMAIL_PASSWORD,
+                smtp_server=os.environ["SMTP_SERVER"],
+                smtp_port=int(os.environ["SMTP_PORT"]),
+                email_username=os.environ["eMAIL_LOGIN"],
+                email_password=os.environ["eMAIL_PASSWORD"],
                 email_subject='Updated impact map for a new Typhoon in PAR',
-                from_address=settings.eMAIL_FROM,
-                to_address_list=settings.eMAIL_LIST,
-                cc_address_list=settings.cC_LIST,
+                from_address=os.environ["EMAIL_FROM"],
+                to_address_list=os.environ["EMAIL_LIST"].split(','),
+                cc_address_list=os.environ["CC_LIST"].split(','),
                 message_html=message_html,
                 filename_list=image_filenames + data_filenames
             )

--- a/IBF-Typhoon-model/src/typhoonmodel/utility_fun/Sendemail.py
+++ b/IBF-Typhoon-model/src/typhoonmodel/utility_fun/Sendemail.py
@@ -1,4 +1,3 @@
-import os
 import smtplib
 import ssl
 from typing import List

--- a/README.md
+++ b/README.md
@@ -11,43 +11,44 @@ The tool is available under the
 To run the pipeline, you need access to an FTP server. 
 If you or your organization is interested in using the pipeline, 
 please contact [510 Global](https://www.510.global/contact-us/)
-to obtain the credentials.  You will receive a file called `settings.py`, which you need to place in 
-the `IBF-Typhoon-model/lib` directory.
+to obtain the credentials.  You will receive a file called `secrets`, which you need to place in 
+the top-level directory.
 
 ### Without Docker
 
-The main script for the pipeline is `IBF-Typhoon-model/scr/pipeline.py`.
-It can in principle be run locally by setting up your local Python environment using
-the `requirements.txt` file, and installing all the R packages listed in the `Dockerfile`.
-However, we suggest using the docker image instead.
+The main code for the pipeline is `IBF-Typhoon-model/src/`, which can in principle be run locally,
+however we do recommend using Docker if you can.
+To run locally:
+
+1. Enter the `IBF-Typhoon-model` directory and install the required Python packages, as
+    well as the `typhoonmodel` package:
+    ```
+    pip install -r requirements.pip
+    pip install .
+    ```
+2. Install all packages listed at the top of the R script `run_model_v2.R`.
+3. Ensure that all the parameters from the `secrets` file have been exported as environment variables
+4. Execute:
+    ```
+    run-typhoon-model [OPTIONS]
+
+    Options:
+      --path TEXT             main directory defult 
+      --remote_directory TEXT                  remote directory 
+      --typhoonname TEXT               name for active typhoon
+    ```
+    When there is an active typhoon in the PAR polygon the model will run for the active typhoons,
+    unless you specify a remote directory and typhoon name. 
 
 ### With Docker
 
-You will need to have docker installed, and you should modify `Docker-settings`
-to set the container memory to at least 2GB
+You will need to have `docker` and `docker-compose` installed.
+You need to create an environment variable called `TYPHOONMODEL_OUTPUT` that contains
+the path to where you would like the model run output data to go.
 
-####  Build the image
+#### Running 
 
-To build the docker image, run:
+To build and run the image, ensure you are in the top-level directory and execute:
 ```
-docker build -t rodekruis510/typhoonibf .
+docker-compose up
 ```
-## Running
-To spin up and enter the docker container, create a directory where you would like
-the output data to go. Then run:
-```
-docker run --rm -it --name=fbf-phv3 -v $path-to-output-directory:/home/fbf/forecast -p 587:587 rodekruis510/typhoonibf bash
-```
-
-To run the pipeline, enter the container and execute:
-```
-run-typhoon-model [OPTIONS]
-
-Options:
-  --path TEXT             main directory defult 
-  --remote_directory TEXT                  remote directory 
-  --typhoonname TEXT               name for active typhoon
-```
-
-When there is an active typhoon in the PAR polygon the model will run for the active typhoons,
-unless you specify a remote directory and typhoon name. 

--- a/README.md
+++ b/README.md
@@ -52,3 +52,8 @@ To build and run the image, ensure you are in the top-level directory and execut
 ```
 docker-compose up
 ```
+When you are finished, run
+```
+docker-compose down
+```
+to remove any docker container(s).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  fbf-phv3:
+    build: .
+    image: rodekruis510/typhoonibf:latest
+    ports:
+      - "587:587"
+    env_file:
+      - secrets
+    volumes:
+      - $TYPHOONMODEL_OUTPUT:/home/fbf/forecast
+    command: run-typhoon-model


### PR DESCRIPTION
In order to not put the settings file into the docker image, I've switched to using environment variables. When running locally these can be passed using a file called `settings`. 

Since there are quite a few inputs to the `docker run` command, I made a `docker-compose` and updated the README so that a user can in principle just run `docker-compose up` and everything will be taken care of. I've made it so that with `docker-compose` the pipeline is automatically executed with default parameters, but this can be changed if you want. 