### PR TITLE
Hotfix: Climada logging and ECWMF error catching

### DIFF
--- a/IBF-Typhoon-model/src/climada/hazard/tc_tracks_forecast.py
+++ b/IBF-Typhoon-model/src/climada/hazard/tc_tracks_forecast.py
@@ -152,8 +152,8 @@ class TCForecast(TCTracks):
 
             remotefiles = fnmatch.filter(con.nlst(), '*tropical_cyclone*')
             if len(remotefiles) == 0:
-                msg = 'No tracks found at ftp://{}/{}'
-                msg.format(ECMWF_FTP, remote_dir)
+                # TODO: Make a PR in climada for this
+                msg = 'No tracks found at ftp://{}/{}'.format(ECMWF_FTP, remote_dir)
                 raise FileNotFoundError(msg)
 
             localfiles = []

--- a/IBF-Typhoon-model/src/typhoonmodel/pipeline.py
+++ b/IBF-Typhoon-model/src/typhoonmodel/pipeline.py
@@ -135,9 +135,10 @@ def main(path,debug,remote_directory,typhoonname):
             fcast.fetch_ecmwf(files=bufr_files)
         except ftplib.all_errors as e:
             n_tries += 1
-            if n_tries > ECMWF_MAX_TRIES:
-                logger.error(f'Exceeded {ECMWF_MAX_TRIES} tries, exiting')
-                SystemExit(e)
+            if n_tries >= ECMWF_MAX_TRIES:
+                logger.error(f' Data downloading from ECMWF failed: {e}, '
+                             f'reached limit of {ECMWF_MAX_TRIES} tries, exiting')
+                sys.exit()
             logger.error(f' Data downloading from ECMWF failed: {e}, retrying after {ECMWF_SLEEP} s')
             time.sleep(ECMWF_SLEEP)
             continue


### PR DESCRIPTION
A couple of fixes:
- Climada log string formatting (need to make PR with the source code)
- When ECMWF download fails, need to use `sys.exit` instead of `SystemExit` as the latter raises an exception that keeps being caught 